### PR TITLE
Change concat join from "inner" to "outer"

### DIFF
--- a/profiles/utils.py
+++ b/profiles/utils.py
@@ -96,6 +96,6 @@ def concat_dataframes(main_df, df):
         main_df = df.copy()
     else:
         frame = [main_df, df]
-        main_df = pd.concat(frame, ignore_index=True, join="inner")
+        main_df = pd.concat(frame, ignore_index=True)
 
     return main_df


### PR DESCRIPTION
This is fix the problem that arises when `Metadata` fields are not the same during feature selection.